### PR TITLE
Fix pads when align center and borders enabled.

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,9 +10,6 @@ export default function ui (opts) {
       return wcswidth(stripAnsi(str))
     },
     stripAnsi,
-
-
-
     wrap,
   })
 }

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -150,7 +150,6 @@ export class UI {
     this.rasterize(row).forEach((rrow, r) => {
       let str = ''
       rrow.forEach((col: string, c: number) => {
-        const { width } = row[c] // the width with padding.
         const wrapWidth = this.negatePadding(row[c]) // the width without padding.
         let ts = col // temporary string used during alignment/padding.
         const strWidth = mixin.stringWidth(col.trim())

--- a/lib/index.ts
+++ b/lib/index.ts
@@ -163,7 +163,7 @@ export class UI {
           const fn = align[(row[c].align as 'right'|'center')]
           ts = fn(ts, wrapWidth)
           if (mixin.stringWidth(ts) < wrapWidth) {
-            ts += ' '.repeat((width || 0) - mixin.stringWidth(ts) - 1)
+            ts = ts.padEnd(wrapWidth);
           }
         }
         // apply border and padding to string.

--- a/test/cliui.test.js
+++ b/test/cliui.test.js
@@ -171,9 +171,9 @@ describe('cliui', () => {
 
       // it should right-align the second column.
       const expected = [
-        'i am a string          i am a second       i am a third string',
-        '                           string          that should be',
-        '                                           wrapped'
+        'i am a string          i am a second    i am a third string',
+        '                           string       that should be',
+        '                                        wrapped'
       ]
 
       ui.toString().split('\n').should.eql(expected)
@@ -194,8 +194,8 @@ describe('cliui', () => {
 
       // it should add left/right padding to columns.
       const expected = [
-        '    i have     i have      i have no',
-        '    padding  padding on    padding',
+        '    i have     i have     i have no',
+        '    padding  padding on   padding',
         '    on my     my right',
         '    left'
       ]


### PR DESCRIPTION
When using `{ align: center, border: true }` options, there was too much spaces, here is a preview of the problem and the fix:

<img width="714" alt="Capture d’écran 2022-12-21 à 12 51 33" src="https://user-images.githubusercontent.com/39910767/208899044-03634387-e99f-4617-b470-ea4a60d4f469.png">
